### PR TITLE
Remove local endpoint redirection URLs from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ Using the public Thunderbird application:
 ```toml
 client-id = "406964657835-aq8lmia8j95dhl1a2bvharmfk3t1hgqj.apps.googleusercontent.com"
 client-secret.raw = "kSmqreRr0qwBWJgbf5Y-PjSU"
-endpoints.redirection = "http://localhost"
 ```
 
 Using your [own application](https://developers.google.com/identity/protocols/oauth2):
@@ -156,7 +155,6 @@ Using the public Thunderbird application:
 
 ```toml
 client-id = "9e5f94bc-e8a4-4e73-b8be-63364c29d753"
-endpoints.redirection = "https://localhost"
 ```
 
 Using your [own application](https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth):


### PR DESCRIPTION
Using the previously provided `endpoints.redirection` value causes the following error:

```
Error: Permission denied (os error 13)
```

Likely because of trying to use port 80 as I read in the issues. Removing these for an easier onboarding for beginners as there is a default value that just works.

Maybe have a separate mention in the README that this endpoint can be changed? (There is already one in the sample config file btw)